### PR TITLE
Update URI for OpenJDK image source example

### DIFF
--- a/layouts/partials/features.html
+++ b/layouts/partials/features.html
@@ -16,7 +16,7 @@ description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJD
       <p>
         See the
         <a
-          href="https://github.com/jboss-container-images/openjdk/blob/develop/ubi8-openjdk-8.yaml"
+          href="https://github.com/jboss-container-images/openjdk/blob/ubi9/ubi9-openjdk-21.yaml"
           >OpenJDK image</a
         >
         for full example.


### PR DESCRIPTION
The old URI references the `develop` branch of the openjdk repo which is not used anymore and might go away.